### PR TITLE
Added support for options.locals

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -55,6 +55,11 @@ module.exports = class JadedBrunchPlugin
     if options.staticPatterns?
       @staticPatterns = options.staticPatterns
 
+    if options.locals?
+      @locals = options.locals
+    else
+      @locals = {}
+
     if options.path?
       @staticPath = options.path
     else if @config.paths?.public?
@@ -135,8 +140,7 @@ module.exports = class JadedBrunchPlugin
         return
 
       if pathTestResults.length
-        locals = options.locals or {}
-        output = template(locals)
+        output = template(@locals)
 
         staticPath = path.join @projectPath, @staticPath
         matches = relativePath.match pathTestResults[0]

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -135,7 +135,8 @@ module.exports = class JadedBrunchPlugin
         return
 
       if pathTestResults.length
-        output = template()
+        locals = options.locals or {}
+        output = template(locals)
 
         staticPath = path.join @projectPath, @staticPath
         matches = relativePath.match pathTestResults[0]


### PR DESCRIPTION
Previously there was no possible way of passing locals from `config.plugins.jaded` to the template rendering. This commit adds support for `config.plugins.jaded.locals` object passed to each template file.