### PR TITLE
Exposed currently compiling filename in locals.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -140,7 +140,8 @@ module.exports = class JadedBrunchPlugin
         return
 
       if pathTestResults.length
-        output = template @locals
+        locals = _.extend {filename: relativePath}, @locals
+        output = template locals
 
         staticPath = path.join @projectPath, @staticPath
         matches = relativePath.match pathTestResults[0]


### PR DESCRIPTION
This can be helpful in cases where we want to know what template is "current", as in a shared navigation that will style the appropriate items as active for the page that's being rendered. Using the local variable "filename" is following from [static-jade-brunch](https://github.com/ilkosta/static-jade-brunch/blob/master/src/index.coffee#L130).