### PR TITLE
Fixed crash bug in latest Brunch

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -171,7 +171,7 @@ module.exports = class JadedBrunchPlugin
               if err
                 callback err, null
               else
-                callback(null, data)
+                callback(null, "") # emit no JS source code
 
       else
         callback null, "module.exports = #{template};"

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -171,7 +171,7 @@ module.exports = class JadedBrunchPlugin
               if err
                 callback err, null
               else
-                callback()
+                callback(null, data)
 
       else
         callback null, "module.exports = #{template};"


### PR DESCRIPTION
The current version of brunch and current version of jaded-brunch crash on compiling a .static.jade file. The cause of this is not passing the second parameter into callback on successful execution of the compile function.