### PR TITLE
Add option for manually providing runtime files.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -47,6 +47,15 @@ module.exports = class JadedBrunchPlugin
     @getDependencies = (compiler, data, path) ->
       discoverDependencies data, path, compiler
 
+  getRuntimeFiles: (runtimeFiles) ->
+    if runtimeFiles?
+      return [] unless runtimeFiles
+      return runtimeFiles
+
+    return [
+      path.join jadePath, '..', 'runtime.js'
+    ]
+
   configure: ->
     if @config.plugins?.jaded?
       options = @config?.plugins?.jaded or @config.plugins.jade
@@ -78,10 +87,7 @@ module.exports = class JadedBrunchPlugin
 
     jadePath = path.dirname require.resolve 'jade'
 
-    @include = [
-      path.join jadePath, '..', 'runtime.js'
-    ]
-
+    @include = @getRuntimeFiles options.runtimeFiles
     jadeModule = options.module or 'jade'
 
     @jade = localRequire jadeModule


### PR DESCRIPTION
Provides a way to manually specify runtime files instead of always injecting them into the build output. It can be set to a list of file paths in order to have those files built in the final output.

if the `runtimeFiles` option is set to _false_ then no files will be provided.

/cc @samme
